### PR TITLE
Keyguard: Squash undo UI changes after merge of branch 'LA.BF64.1.2.2…

### DIFF
--- a/packages/Keyguard/res/values/bools.xml
+++ b/packages/Keyguard/res/values/bools.xml
@@ -17,5 +17,4 @@
 <resources>
     <bool name="kg_show_ime_at_screen_on">true</bool>
     <bool name="kg_use_all_caps">true</bool>
-    <bool name="kg_hide_emgcy_btn_when_oos">false</bool>
 </resources>

--- a/packages/Keyguard/src/com/android/keyguard/EmergencyButton.java
+++ b/packages/Keyguard/src/com/android/keyguard/EmergencyButton.java
@@ -22,10 +22,8 @@ import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.PowerManager;
 import android.os.SystemClock;
-import android.os.SystemProperties;
 import android.os.UserHandle;
 import android.telecom.TelecomManager;
-import android.telephony.ServiceState;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.Button;
@@ -57,11 +55,6 @@ public class EmergencyButton extends Button {
 
         @Override
         public void onPhoneStateChanged(int phoneState) {
-            updateEmergencyCallButton();
-        }
-
-        @Override
-        public void onServiceStateChanged(int sub, ServiceState state) {
             updateEmergencyCallButton();
         }
     };
@@ -142,7 +135,7 @@ public class EmergencyButton extends Button {
         }
     }
 
-    public void updateEmergencyCallButton() {
+    private void updateEmergencyCallButton() {
         boolean visible = false;
         if (mIsVoiceCapable) {
             // Emergency calling requires voice capability.
@@ -156,13 +149,7 @@ public class EmergencyButton extends Button {
                     visible = mEnableEmergencyCallWhileSimLocked;
                 } else {
                     // Only show if there is a secure screen (pin/pattern/SIM pin/SIM puk);
-                    visible = mLockPatternUtils.isSecure(KeyguardUpdateMonitor.getCurrentUser()) ||
-                            SystemProperties.getBoolean("persist.radio.emgcy_btn_onswipe", false);
-                }
-
-                if (mContext.getResources().getBoolean(R.bool.kg_hide_emgcy_btn_when_oos)) {
-                    KeyguardUpdateMonitor monitor = KeyguardUpdateMonitor.getInstance(mContext);
-                    visible = visible && !monitor.isOOS();
+                    visible = mLockPatternUtils.isSecure(KeyguardUpdateMonitor.getCurrentUser());
                 }
             }
         }

--- a/packages/Keyguard/src/com/android/keyguard/KeyguardUpdateMonitor.java
+++ b/packages/Keyguard/src/com/android/keyguard/KeyguardUpdateMonitor.java
@@ -1356,7 +1356,6 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener {
             KeyguardUpdateMonitorCallback cb = mCallbacks.get(j).get();
             if (cb != null) {
                 cb.onRefreshCarrierInfo();
-                cb.onServiceStateChanged(subId, serviceState);
             }
         }
     }
@@ -1583,21 +1582,6 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener {
         } else {
             return State.UNKNOWN;
         }
-    }
-
-    public boolean isOOS()
-    {
-        boolean ret = true;
-        for (int subId : mServiceStates.keySet()) {
-            ServiceState state = mServiceStates.get(subId);
-            if (((state.getVoiceRegState() != ServiceState.STATE_OUT_OF_SERVICE)
-                    && (state.getVoiceRegState() != ServiceState.STATE_POWER_OFF))
-                    || (state.isEmergencyOnly())) {
-                ret = false;
-                break;
-            }
-        }
-        return ret;
     }
 
     /**

--- a/packages/Keyguard/src/com/android/keyguard/KeyguardUpdateMonitorCallback.java
+++ b/packages/Keyguard/src/com/android/keyguard/KeyguardUpdateMonitorCallback.java
@@ -20,7 +20,6 @@ import android.graphics.Bitmap;
 import android.media.AudioManager;
 import android.os.SystemClock;
 import android.hardware.fingerprint.FingerprintManager;
-import android.telephony.ServiceState;
 import android.telephony.TelephonyManager;
 import android.view.WindowManagerPolicy;
 
@@ -122,13 +121,6 @@ public class KeyguardUpdateMonitorCallback {
      * @param simState
      */
     public void onSimStateChanged(int subId, int slotId, IccCardConstants.State simState) { }
-
-    /**
-     * Called when the sevice state changes.
-     * @param subId
-     * @param serviceState
-     */
-    public void onServiceStateChanged(int sub, ServiceState state) { }
 
     /**
      * Called when the user's info changed.

--- a/packages/SystemUI/res/layout/keyguard_bottom_area.xml
+++ b/packages/SystemUI/res/layout/keyguard_bottom_area.xml
@@ -36,15 +36,6 @@
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:accessibilityLiveRegion="polite" />
 
-    <include layout="@layout/keyguard_eca"
-        android:id="@+id/keyguard_selector_fade_container"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="36dp"
-        android:orientation="vertical"
-        android:layout_gravity="bottom|center_horizontal"
-        android:gravity="center_horizontal" />
-
     <FrameLayout
         android:id="@+id/preview_container"
         android:layout_width="match_parent"

--- a/packages/SystemUI/res/values/dimens.xml
+++ b/packages/SystemUI/res/values/dimens.xml
@@ -484,7 +484,7 @@
     <dimen name="keyguard_affordance_icon_height">24dp</dimen>
     <dimen name="keyguard_affordance_icon_width">24dp</dimen>
 
-    <dimen name="keyguard_indication_margin_bottom">90dp</dimen>
+    <dimen name="keyguard_indication_margin_bottom">65dp</dimen>
 
     <!-- The text size for battery level -->
     <dimen name="battery_level_text_size">12sp</dimen>

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardBottomAreaView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardBottomAreaView.java
@@ -43,7 +43,6 @@ import android.os.IBinder;
 import android.os.Message;
 import android.os.Messenger;
 import android.os.RemoteException;
-import android.os.SystemProperties;
 import android.os.UserHandle;
 import android.provider.MediaStore;
 import android.service.media.CameraPrewarmService;
@@ -59,7 +58,6 @@ import android.view.animation.Interpolator;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 import com.android.internal.widget.LockPatternUtils;
-import com.android.keyguard.EmergencyButton;
 import com.android.keyguard.KeyguardUpdateMonitor;
 import com.android.keyguard.KeyguardUpdateMonitorCallback;
 import com.android.systemui.EventLogConstants;
@@ -104,7 +102,6 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
     private static final int DOZE_ANIMATION_STAGGER_DELAY = 48;
     private static final int DOZE_ANIMATION_ELEMENT_DURATION = 250;
 
-    private EmergencyButton mEmergencyButton;
     private KeyguardAffordanceView mCameraImageView;
     private KeyguardAffordanceView mLeftAffordanceView;
     private LockIcon mLockIcon;
@@ -217,7 +214,6 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
         super.onFinishInflate();
         mLockPatternUtils = new LockPatternUtils(mContext);
         mPreviewContainer = (ViewGroup) findViewById(R.id.preview_container);
-        mEmergencyButton = (EmergencyButton) findViewById(R.id.emergency_call_button);
         mCameraImageView = (KeyguardAffordanceView) findViewById(R.id.camera_button);
         mLeftAffordanceView = (KeyguardAffordanceView) findViewById(R.id.left_button);
         mLockIcon = (LockIcon) findViewById(R.id.lock_icon);
@@ -228,7 +224,6 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
         mUnlockMethodCache = UnlockMethodCache.getInstance(getContext());
         mUnlockMethodCache.addListener(this);
         mLockIcon.update();
-        updateEmergencyButton();
         setClipChildren(false);
         setClipToPadding(false);
         mPreviewInflater = new PreviewInflater(mContext, new LockPatternUtils(mContext));
@@ -285,7 +280,6 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
         mIndicationText.setTextSize(TypedValue.COMPLEX_UNIT_PX,
                 getResources().getDimensionPixelSize(
                         com.android.internal.R.dimen.text_size_small_material));
-        updateEmergencyButton();
     }
 
     public void setActivityStarter(ActivityStarter activityStarter) {
@@ -766,14 +760,6 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
     public void updateLeftAffordance() {
         updateLeftAffordanceIcon();
         updateLeftPreview();
-    }
-
-    private void updateEmergencyButton() {
-        if (SystemProperties.getBoolean("persist.radio.emgcy_btn_onswipe",false)) {
-            if (mEmergencyButton != null) {
-                mEmergencyButton.updateEmergencyCallButton();
-            }
-        }
     }
 
     private String getIndexHint(LockscreenShortcutsHelper.Shortcuts shortcut) {


### PR DESCRIPTION
…_rb4.7'

	Revert "Hide emergency button when OOS"
	This reverts commit 5ccaaff4818af8d48e072cbd2b8b784e5cd0c593.

	* Buggy on MSIM, making the button perma enable.

	Revert "EmergencyCall Button on Swipe Lock Screen"
	This reverts commit 5f712cc90ebb11a04e72ab6b04a1229eeddef9fc.

	* Introduces some ugly padding to make room for a button we have
	  disabled by default since forever.

	Revert "Emergency call button on Swipe lock Screen."
	This reverts commit f17cb289ae5f760a51b8463fe270b336d1e3b408.

	* See above, adds the option to enable the button itself.

Conflicts:
	packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardBottomAreaView.java

Change-Id: Ie95f0b075e25b625298eac3c06d278e6cb1e7b17